### PR TITLE
fix locale issues

### DIFF
--- a/src/components/parallax.jsx
+++ b/src/components/parallax.jsx
@@ -1,3 +1,5 @@
+import {useRouter} from 'next/router';
+import translation from '../utils/translation';
 import styles from './parallax.module.css';
 
 /**
@@ -5,11 +7,14 @@ import styles from './parallax.module.css';
  * @return {JSX.Element}
  */
 export default function Parallax() {
+  const {locale, defaultLocale} = useRouter();
+  const t = translation(locale ?? defaultLocale);
+
   return (
     <div className={styles.parallax}>
       <div className={styles.inner}>
-        <h1>Fityandhiya Islam Nugroho</h1>
-        <h2 lang='en'>Software Engineer</h2>
+        <h1>{t.get('parallaxTitle')}</h1>
+        <h2>{t.get('parallaxSubtitle')}</h2>
       </div>
     </div>
   );

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -5,7 +5,7 @@
     "github": "fityannugroho/fastvoting",
     "deploy": "https://fastvoting.online",
     "download": "",
-    "id-ID": {
+    "id": {
       "title": "FastVoting",
       "description": "Aplikasi web untuk membuat dan mengelola acara pemungutan suara."
     }
@@ -16,7 +16,7 @@
     "github": "fityannugroho/idn-area",
     "deploy": "https://idn-area.herokuapp.com",
     "download": "",
-    "id-ID": {
+    "id": {
       "title": "API Wilayah Indonesia",
       "description": "API yang menyediakan informasi provinsi, kabupaten/kota, kecamatan, dan desa di Indonesia."
     }
@@ -27,7 +27,7 @@
     "github": "fityannugroho/lister",
     "deploy": "",
     "download": "https://github.com/fityannugroho/lister/releases/download/v1.0.0/app-release.apk",
-    "id-ID": {
+    "id": {
       "title": "Aplikasi Lister",
       "description": "Aplikasi Android untuk mencatat daftar kegiatan, dan berbagi dengan pengguna lain."
     }
@@ -38,7 +38,7 @@
     "github": "fityannugroho/faculty-upi",
     "deploy": "https://faculty-upi.herokuapp.com",
     "download": "",
-    "id-ID": {
+    "id": {
       "title": "API Fakultas UPI",
       "description": "API yang menyediakan informasi fakultas dan program studi yang ada di Universitas Pendidikan Indonesia."
     }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -10,6 +10,8 @@ const locale = {
   myDescription: 'You can call me Fityan. I\'m from Indramayu, West Java, Indonesia. I started programming in 2019, and have developed many websites using various programming languages and frameworks.',
   btnResume: 'Read My Resume',
   resumeLink: 'https://drive.google.com/file/d/1lDK_h3c43vZ-KS8KTcWc9KS5u8Ui1FhT/view?usp=share_link',
+  parallaxTitle: 'Hello world, I\'m Fityan!',
+  parallaxSubtitle: 'A Software Engineer',
 };
 
 export default locale;

--- a/src/locales/id.js
+++ b/src/locales/id.js
@@ -1,8 +1,8 @@
 /* eslint-disable max-len */
 
 const locale = {
-  title: 'fityannugroho | Software Engineer',
-  description: 'Halo, Saya Fityandhiya Islam Nugroho, seorang software engineer.',
+  title: 'fityannugroho | Insinyur Perangkat Lunak',
+  description: 'Halo, Saya Fityandhiya Islam Nugroho, seorang insinyur perangkat lunak.',
   navMenu1: 'Tentang',
   navMenu2: 'Proyek',
   navMenu3: 'Kontak',

--- a/src/locales/id.js
+++ b/src/locales/id.js
@@ -10,6 +10,8 @@ const locale = {
   myDescription: 'Anda bisa memanggil saya Fityan. Saya berasal dari Indramayu, Jawa Barat, Indonesia. Saya memulai programming sejak 2019, dan telah banyak mengembangkan website menggunakan berbagai macam bahasa pemrograman dan framework.',
   btnResume: 'Baca Resume Saya',
   resumeLink: 'https://drive.google.com/file/d/1k4502xUe0Wn4Q_S4Pm-Yh8Lg2BXPSwNf/view?usp=share_link',
+  parallaxTitle: 'Halo dunia, Saya Fityan!',
+  parallaxSubtitle: 'Seorang Insinyur Perangkat Lunak',
 };
 
 export default locale;


### PR DESCRIPTION
## What changes

- Rename projects locale id-ID into id (5bb002d5506ad162988faeb76e20e733ffc1d400).
- Fix `id` translation for 'software engineer' in `title` and `description` (3a92a90ccbbe0ea8a0a97009c2a18445b7d21cc8).
- Translate the parallax content (2843709521886cefd2b2eecda0f804c15fc072bf).