### PR TITLE
fix: add support for horizontal rule in RichText serialization

### DIFF
--- a/src/components/RichText/serialize.tsx
+++ b/src/components/RichText/serialize.tsx
@@ -181,6 +181,9 @@ export function serializeLexical({ nodes }: Props): JSX.Element {
               </Link>
             );
           }
+          case "horizontalrule": {
+            return <hr key={key} />;
+          }
 
           default:
             return null;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Issue Number: resolve #234 

## What is the new behavior?
In serialization function, return `<hr />` if the `node.type` equals to `horizontalrule`.