### PR TITLE
fix: use SSR for dynamic blog page, improve CMS response types

### DIFF
--- a/src/components/PayloadCMSPostCard.tsx
+++ b/src/components/PayloadCMSPostCard.tsx
@@ -15,10 +15,10 @@ export function PayloadCMSPostCard({ data: post }: Props) {
       data={{
         title: post.title,
         summary: post.meta.description,
-        postDate: post.createdAt,
+        postDate: new Date(post.createdAt),
         tags: post.categories.map((tag) => tag.title),
-        cover: {
-          ...(post.meta.image && {
+        ...(post.meta.image && {
+          cover: {
             file: {
               src: getImageSrc(post.meta.image.url),
               width: post.meta.image.width,
@@ -26,8 +26,8 @@ export function PayloadCMSPostCard({ data: post }: Props) {
               format: post.meta.image.mimeType.split("/").pop() as MimeType,
             },
             alt: post.meta.image.alt,
-          }),
-        },
+          },
+        }),
       }}
     />
   );

--- a/src/lib/payload-cms.ts
+++ b/src/lib/payload-cms.ts
@@ -26,7 +26,7 @@ export type PayloadCMSPost = {
   }[];
   meta: {
     title: string;
-    image: {
+    image?: {
       id: string;
       alt: string;
       caption: object;
@@ -40,40 +40,57 @@ export type PayloadCMSPost = {
     };
     description: string;
   };
-  publishedAt: Date;
+  publishedAt: string;
   authors: [];
   populatedAuthors: [];
   slug: string;
   slugLock: boolean;
-  updatedAt: Date;
-  createdAt: Date;
+  updatedAt: string;
+  createdAt: string;
   _status: boolean;
+};
+
+type PayloadCMSPostsResponse = {
+  docs: PayloadCMSPost[];
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+  limit: number;
+  nextPage: number | null;
+  page: number;
+  pagingCounter: number | null;
+  prevPage: number | null;
+  totalDocs: number;
+  totalPages: number;
 };
 
 const payloadApiUrl = PUBLIC_PAYLOAD_CMS_URL;
 
 export async function getPosts() {
   const res = await fetch(`${payloadApiUrl}/api/posts`);
-  const data = (await res.json()) as {
-    docs: PayloadCMSPost[];
-    hasNextPage: boolean;
-    hasPrevPage: boolean;
-    limit: number;
-    nextPage: number | null;
-    page: number;
-    pagingCounter: number | null;
-    prevPage: number | null;
-    totalDocs: number;
-    totalPages: number;
-  };
+  const data = (await res.json()) as PayloadCMSPostsResponse;
 
   return data.docs;
 }
 
-export async function getPost(id: string) {
+export async function getPost(id: number) {
   const res = await fetch(`${payloadApiUrl}/api/posts/${id}`);
-  const data = (await res.json()) as PayloadCMSPost;
+  const data = (await res.json()) as PayloadCMSPost | { errors: [] };
+
+  if ("errors" in data) {
+    return null;
+  }
+
   return data;
+}
+
+export async function getPostBySlug(slug: string) {
+  const res = await fetch(
+    `${payloadApiUrl}/api/posts?where[slug][equals]=${slug}`,
+  );
+
+  const data = (await res.json()) as PayloadCMSPostsResponse;
+
+  return data.docs[0] ?? null;
 }
 
 export function getImageSrc(imgUrl: string) {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -2,33 +2,28 @@
 import RichText from "@/components/RichText";
 import { badgeVariants } from "@/components/ui/badge";
 import MainLayout from "@/layouts/MainLayout.astro";
-import { getImageSrc, getPosts } from "@/lib/payload-cms";
+import { getImageSrc, getPostBySlug } from "@/lib/payload-cms";
 import dayjs from "dayjs";
 
-// The getStaticPaths() is required for static Astro sites.
-// If using SSR, you will not need this function.
-export async function getStaticPaths() {
-  let posts = await getPosts();
+export const prerender = false;
 
-  return posts.map((post) => {
-    return {
-      params: { id: post.slug, slug: post.slug },
-      props: {
-        blog: {
-          data: post,
-        },
-        content: post.content,
-      },
-    };
-  });
+const { slug } = Astro.params;
+if (!slug) {
+  return Astro.redirect("404");
 }
 
-const { blog, content } = Astro.props;
+const post = await getPostBySlug(slug);
+if (!post) {
+  return Astro.redirect("404");
+}
+
+const blog = { data: post };
+const content = post.content;
 ---
 <MainLayout
   title={blog.data.title + " | Fityandhiya Islam Nugroho"}
   description={blog.data.meta.description}
-  ogImage={getImageSrc(blog.data.meta.image.url)}
+  ogImage={blog.data.meta.image ? getImageSrc(blog.data.meta.image.url) : ''}
   className="container container-wrapper"
 >
   <article class="prose lg:prose-lg dark:prose-invert mx-auto">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -12,7 +12,9 @@ const posts = await getPosts();
 blogEntries.sort(
   (a, b) => b.data.postDate.getTime() - a.data.postDate.getTime(),
 );
-posts.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+posts.sort(
+  (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+);
 ---
 
 <MainLayout title="Blog | Fityandhiya Islam Nugroho">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,9 @@ import { getPosts } from "@/lib/payload-cms";
 import { ArrowRightIcon } from "lucide-react";
 
 const posts = await getPosts();
-posts.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+posts.sort(
+  (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+);
 
 const projects = await getCollection("projects");
 ---


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Issue Number: resolve #237 

## What is the new behavior?
- Rename dynamic blog page file from `[id].astro` into `[slug].astro`.
- For dynamic blog page `/blog/[slug]`, set `prerender` to `false` to use SSR.
- Create `getPostBySlug` function, querying post by slug [see Payload CMS queries](https://payloadcms.com/docs/queries/overview).
- Update `getPost` function to accept `id` in `number` (previously `string`)
- Improve Payload CMS response typing:
  - Change `publishedAt`, `updatedAt`, and `createdAt` from `Date` to `string`.
  - `image` now nullable.

### Updated screenshot

![Screenshot after fixing](https://github.com/user-attachments/assets/580a500a-204f-410f-ba1f-f8444b2f979e)
