### PR TITLE
Fix banner serialization

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,5 +1,15 @@
 import { cn } from "@/lib/utils";
-import type { ComponentProps } from "react";
+import {
+  AlertCircleIcon,
+  CheckIcon,
+  InfoIcon,
+  type LucideProps,
+} from "lucide-react";
+import type {
+  ComponentProps,
+  ForwardRefExoticComponent,
+  RefAttributes,
+} from "react";
 import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 
 type AlertProps = ComponentProps<typeof Alert>;
@@ -17,18 +27,34 @@ const variantBannerStyleMapping: Readonly<
   error: "destructive",
 } as const;
 
+export const bannerIcon: Record<
+  NonNullable<AlertProps["variant"]>,
+  ForwardRefExoticComponent<
+    Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>
+  >
+> = {
+  default: InfoIcon,
+  success: CheckIcon,
+  warning: AlertCircleIcon,
+  destructive: AlertCircleIcon,
+};
+
 export default function Banner({
   children,
   style,
   className,
   ...props
 }: BannerProps) {
+  const variant = variantBannerStyleMapping[style];
+  const BannerIcon = variant ? bannerIcon[variant] : bannerIcon.default;
+
   return (
     <Alert
       {...props}
-      variant={variantBannerStyleMapping[style]}
+      variant={variant}
       className={cn("not-prose my-6", className)}
     >
+      <BannerIcon className="h-4 w-4" />
       <AlertTitle>{style}</AlertTitle>
       <AlertDescription>{children}</AlertDescription>
     </Alert>

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+import type { ComponentProps } from "react";
+import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
+
+type AlertProps = ComponentProps<typeof Alert>;
+
+export type BannerProps = Omit<AlertProps, "variant"> & {
+  style: string;
+};
+
+const variantBannerStyleMapping: Readonly<
+  Record<string, NonNullable<AlertProps["variant"]>>
+> = {
+  info: "default",
+  success: "success",
+  warning: "warning",
+  error: "destructive",
+} as const;
+
+export default function Banner({
+  children,
+  style,
+  className,
+  ...props
+}: BannerProps) {
+  return (
+    <Alert
+      {...props}
+      variant={variantBannerStyleMapping[style]}
+      className={cn("not-prose my-6", className)}
+    >
+      <AlertTitle>{style}</AlertTitle>
+      <AlertDescription>{children}</AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import {
-  AlertCircleIcon,
+  AlertTriangleIcon,
   CheckIcon,
   InfoIcon,
   type LucideProps,
@@ -21,7 +21,7 @@ export type BannerProps = Omit<AlertProps, "variant"> & {
 const variantBannerStyleMapping: Readonly<
   Record<string, NonNullable<AlertProps["variant"]>>
 > = {
-  info: "default",
+  info: "info",
   success: "success",
   warning: "warning",
   error: "destructive",
@@ -34,9 +34,10 @@ export const bannerIcon: Record<
   >
 > = {
   default: InfoIcon,
+  info: InfoIcon,
   success: CheckIcon,
-  warning: AlertCircleIcon,
-  destructive: AlertCircleIcon,
+  warning: AlertTriangleIcon,
+  destructive: AlertTriangleIcon,
 };
 
 export default function Banner({
@@ -46,7 +47,7 @@ export default function Banner({
   ...props
 }: BannerProps) {
   const variant = variantBannerStyleMapping[style];
-  const BannerIcon = variant ? bannerIcon[variant] : bannerIcon.default;
+  const BannerIcon = variant ? bannerIcon[variant] : bannerIcon.info;
 
   return (
     <Alert
@@ -54,8 +55,8 @@ export default function Banner({
       variant={variant}
       className={cn("not-prose my-6", className)}
     >
-      <BannerIcon className="h-4 w-4" />
-      <AlertTitle>{style}</AlertTitle>
+      <BannerIcon className="h-5 w-5" />
+      <AlertTitle className="capitalize font-bold">{style}</AlertTitle>
       <AlertDescription>{children}</AlertDescription>
     </Alert>
   );

--- a/src/components/RichText/serialize.tsx
+++ b/src/components/RichText/serialize.tsx
@@ -1,4 +1,5 @@
 import { Fragment, type JSX } from "react";
+import Banner from "../Banner";
 import { EmbeddedSocialMedia } from "../EmbeddedSocialMedia";
 import { Link } from "../Link";
 import MediaBlock from "../MediaBlock";
@@ -106,12 +107,13 @@ export function serializeLexical({ nodes }: Props): JSX.Element {
           switch (blockType) {
             case "mediaBlock":
               return <MediaBlock key={key} media={block.media} />;
-            case "banner":
+            case "banner": {
               return (
-                <div key={key} className="banner">
-                  {serializeLexical(block.content.root)}
-                </div>
+                <Banner style={block.style}>
+                  {serializedChildrenFn(block.content.root)}
+                </Banner>
               );
+            }
             case "code":
               return (
                 <pre key={key}>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,60 @@
+import { cn } from "@/lib/utils";
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        success: "border-success/50 text-success dark:border-success",
+        warning: "border-warning/50 text-warning dark:border-warning",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -8,8 +8,11 @@ const alertVariants = cva(
     variants: {
       variant: {
         default: "bg-background text-foreground",
-        success: "border-success/50 text-success dark:border-success",
-        warning: "border-warning/50 text-warning dark:border-warning",
+        info: "border-primary/50 text-primary dark:border-primary dark:bg-opacity-10 dark:text-primary [&>svg]:text-primary",
+        success:
+          "border-success/50 text-success dark:border-success [&>svg]:text-success",
+        warning:
+          "border-warning/50 text-warning dark:border-warning [&>svg]:text-warning",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
       },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,6 +25,12 @@
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
 
+    --success: 120 100% 50%;
+    --success-foreground: 0 0% 98%;
+
+    --warning: 38 92% 50%;
+    --warning-foreground: 48 96% 89%;
+
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
@@ -59,6 +65,12 @@
 
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
+
+    --success: 120 37% 12%;
+    --success-foreground: 120 100% 50%;
+
+    --warning: 48 96% 89%;
+    --warning-foreground: 38 92% 50%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,13 +25,13 @@
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
 
-    --success: 120 100% 50%;
-    --success-foreground: 0 0% 98%;
+    --success: 143.8 61.2% 20.2%;
+    --success-foreground: 141 78.9% 85.1%;
 
-    --warning: 38 92% 50%;
-    --warning-foreground: 48 96% 89%;
+    --warning: 32.1 94.6% 43.7%;
+    --warning-foreground: 48 100% 96.1%;
 
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0, 72%, 51%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 214.3 31.8% 91.4%;
@@ -66,13 +66,13 @@
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
 
-    --success: 120 37% 12%;
-    --success-foreground: 120 100% 50%;
+    --success: 142 69% 58%;
+    --success-foreground: 143.8 61.2% 20.2%;
 
-    --warning: 48 96% 89%;
-    --warning-foreground: 38 92% 50%;
+    --warning: 45.4 93.4% 47.5%;
+    --warning-foreground: 28.4 72.5% 25.7%;
 
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 217.2 32.6% 17.5%;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -26,6 +26,14 @@ export default {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",
         },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Banner not shown.

## What is the new behavior?
This pull request introduces a new `Banner` component and integrates it into the existing codebase. The changes include defining the `Banner` component, updating the serialization logic to use the new component, and adding necessary styles and configurations.

### New `Banner` Component:
* [`src/components/Banner.tsx`](diffhunk://#diff-03ef1631eb5274cb7b05dfcc6d3025be1797d2a6b23211de142d5673b8ec580cR1-R63): Created a new `Banner` component that uses the `Alert`, `AlertTitle`, and `AlertDescription` components to display different types of alerts based on the `style` prop.

### Integration into Existing Codebase:
* [`src/components/RichText/serialize.tsx`](diffhunk://#diff-958f0d6b8317f21d564812f24641e1a066dd6caa714656bbf5edebacfc4120beR2): Updated the `serializeLexical` function to use the new `Banner` component for rendering banner blocks.

### Supporting Components and Styles:
* [`src/components/ui/alert.tsx`](diffhunk://#diff-74bb2be90925350671a0ba4f34ddcd603d883248074958bc088b2abbad25a1b1R1-R63): Added `Alert`, `AlertTitle`, and `AlertDescription` components to support the `Banner` component.
* [`src/styles/globals.css`](diffhunk://#diff-dd438e7ca4da8a47a35709920a07b6fef918609c1daa40f6e9b794ddfd3e4996L28-R34): Added new CSS variables for `success` and `warning` color schemes to support the new `Banner` component styles. [[1]](diffhunk://#diff-dd438e7ca4da8a47a35709920a07b6fef918609c1daa40f6e9b794ddfd3e4996L28-R34)
* [`tailwind.config.mjs`](diffhunk://#diff-aff1492b58cdb20ff9554dba377672d03b18f6f9ba80a56ff7d4cc6e60a4ae07R29-R36): Updated Tailwind configuration to include `success` and `warning` color schemes.