### PR TITLE
fix: correct redirect path for 404 errors in blog slug page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,17 @@
+---
+import { Link } from "@/components/Link";
+import MainLayout from "@/layouts/MainLayout.astro";
+import { AlertTriangle } from "lucide-react";
+---
+
+<MainLayout
+  title="Page Not Found"
+  description="Oops! The page you're looking for doesn't exist."
+>
+  <div class="text-center">
+    <AlertTriangle size={64} className="text-destructive mx-auto" />
+    <h1 class="text-4xl font-bold mt-4">404 Not Found</h1>
+    <p class="text-lg mt-2">Oops! The page you're looking for doesn't exist.</p>
+    <Link href="/" variant='default' className="mt-4">Go Home</Link>
+  </div>
+</MainLayout>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -8,12 +8,12 @@ export const prerender = false;
 
 const { slug } = Astro.params;
 if (!slug) {
-  return Astro.redirect("404");
+  return Astro.redirect("/404");
 }
 
 const post = await getPostBySlug(slug);
 if (!post) {
-  return Astro.redirect("404");
+  return Astro.redirect("/404");
 }
 ---
 <MainLayout


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Wrong redirect when blog post is not found.

It must redirect to `/404` by default (see the [docs](https://docs.astro.build/en/basics/astro-pages/#custom-404-error-page))

## What is the new behavior?
This pull request includes updates to the 404 error page and a fix for the blog post redirection logic. The most important changes are:

### 404 Error Page Update:
* Added a new custom 404 error page with a user-friendly message and a link to return to the homepage. (`src/pages/404.astro`)

### Blog Post Redirection Fix:
* Updated the redirection logic in the blog post page to correctly redirect to the custom 404 error page when a post is not found. (`src/pages/blog/[slug].astro`) ([src/pages/blog/[slug].astroL11-R16](diffhunk://#diff-c8e7929728443eef3921004f841ccbf1f6000b152eba780e1eabaa7b150f8cf8L11-R16))