### PR TITLE
fix: `Banner` component styling

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -51,11 +51,7 @@ export default function Banner({
   const BannerIcon = variant ? bannerIcon[variant] : bannerIcon.info;
 
   return (
-    <Alert
-      {...props}
-      variant={variant}
-      className={cn("not-prose my-6", className)}
-    >
+    <Alert {...props} variant={variant} className={cn("my-6", className)}>
       <BannerIcon className="h-5 w-5" />
       <AlertTitle className="capitalize font-bold text-base">
         {style}

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -45,7 +45,7 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({
           data={node.fields.content}
           enableGutter={false}
           enableProse={true}
-          className="text-inherit [&_*]:text-inherit prose-p:my-3 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0 prose-a:font-semibold"
+          className="text-inherit [&_*]:text-inherit prose-p:my-3 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0"
         />
       </Banner>
     ),

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -44,8 +44,8 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({
         <RichText
           data={node.fields.content}
           enableGutter={false}
-          enableProse={false}
-          className="w-full color-[inherit] prose-base"
+          enableProse={true}
+          className="text-inherit [&_*]:text-inherit prose-p:my-3 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0"
         />
       </Banner>
     ),

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -45,7 +45,7 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({
           data={node.fields.content}
           enableGutter={false}
           enableProse={true}
-          className="text-inherit [&_*]:text-inherit prose-p:my-3 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0"
+          className="text-inherit [&_*]:text-inherit prose-p:my-3 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0 prose-a:font-semibold"
         />
       </Banner>
     ),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
There are no gaps between paragraphs in `Banner` component.

## What is the new behavior?
This pull request includes updates to the `Banner` and `RichText` components to improve their styling and behavior. The most important changes are as follows:

Styling improvements:
* [`src/components/Banner.tsx`](diffhunk://#diff-03ef1631eb5274cb7b05dfcc6d3025be1797d2a6b23211de142d5673b8ec580cL54-R54): Simplified the `Alert` component's properties by removing the `not-prose` class.
* [`src/components/RichText.tsx`](diffhunk://#diff-74c35a105c369d2c177b8c4c3246c614ef34e52a449a12a707b9539087b0af07L47-R48): Enabled the `prose` styling and updated the class names to ensure consistent text inheritance and spacing.

| Before | After |
|---|---|
| ![ss before](https://github.com/user-attachments/assets/b5054f96-880f-4442-988d-11ec4a6d3f5f) | ![ss after](https://github.com/user-attachments/assets/155ef99b-ed75-46c4-b446-4a46e7d31191) |

