### PR TITLE
fix: set prerender to `false` for `/projects` page

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -5,6 +5,8 @@ import MainLayout from "@/layouts/MainLayout.astro";
 import { getProjects } from "@/lib/payload-cms";
 import { ExternalLinkIcon } from "lucide-react";
 
+export const prerender = false;
+
 const projects = await getProjects();
 ---
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
The project list didn't updated after modification in CMS.

## What is the new behavior?
This pull request includes a small change to the `src/pages/projects.astro` file. The change adds a new export statement to disable prerendering for the projects page.

* [`src/pages/projects.astro`](diffhunk://#diff-0bcddd1a64bdf0b6e3720fb396b0d7e12710509efdd0ae2080d21796d9ac66d2R8-R9): Added `export const prerender = false;` to disable prerendering for the projects page.