### PR TITLE
feat: add sorting options for posts and projects

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -7,14 +7,13 @@ import { getPosts } from "@/lib/payload-cms";
 export const prerender = false;
 
 const blogEntries = await getCollection("blog");
-const posts = await getPosts();
+const posts = await getPosts({
+  sort: { updatedAt: "desc" },
+});
 
 // Sort by date in descending order
 blogEntries.sort(
   (a, b) => b.data.postDate.getTime() - a.data.postDate.getTime(),
-);
-posts.sort(
-  (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
 );
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,12 +9,13 @@ import { ArrowRightIcon } from "lucide-react";
 
 export const prerender = false;
 
-const posts = await getPosts();
-posts.sort(
-  (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-);
+const posts = await getPosts({
+  sort: { updatedAt: "desc" },
+});
 
-const projects = await getProjects();
+const projects = await getProjects({
+  sort: { updatedAt: "desc" },
+});
 ---
 
 <MainLayout disableWrapper>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -7,7 +7,9 @@ import { ExternalLinkIcon } from "lucide-react";
 
 export const prerender = false;
 
-const projects = await getProjects();
+const projects = await getProjects({
+  sort: { updatedAt: "desc" },
+});
 ---
 
 <MainLayout title="My Projects | Fityandhiya Islam Nugroho">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
The sorting operations for `posts` and `projects` data from the CMS is performed locally.

## What is the new behavior?
This pull request introduces a new sorting functionality for fetching posts and projects from the Payload CMS API. The changes include the addition of a utility function to convert sort options to a query string, and the modification of existing functions to support sorting.

### Sorting Functionality:

* [`src/lib/payload-cms.ts`](diffhunk://#diff-d2ce7541510ac0121297e46690c73d65b91e0fddccab8e9b0d17dbddad28ba51L29-R59): Added a `SortOptions` type and a `stringifySortOptions` function to convert sort objects to query strings for the Payload CMS API. Modified `getPosts` and `getProjects` functions to accept an optional `sort` parameter and append it to the API request URL. [[1]](diffhunk://#diff-d2ce7541510ac0121297e46690c73d65b91e0fddccab8e9b0d17dbddad28ba51L29-R59) [[2]](diffhunk://#diff-d2ce7541510ac0121297e46690c73d65b91e0fddccab8e9b0d17dbddad28ba51L61-R97)

### Updates to API Calls:

* [`src/pages/blog/index.astro`](diffhunk://#diff-a64eb99d116304a8bedfb2764ef2708e4ede269e512028d3eca22ba03651153aL10-L18): Updated the call to `getPosts` to include sorting by `updatedAt` in descending order.
* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L12-R18): Updated the calls to `getPosts` and `getProjects` to include sorting by `updatedAt` in descending order.
* [`src/pages/projects.astro`](diffhunk://#diff-0bcddd1a64bdf0b6e3720fb396b0d7e12710509efdd0ae2080d21796d9ac66d2L10-R12): Updated the call to `getProjects` to include sorting by `updatedAt` in descending order.