### PR TITLE
feat: use Umami, replace vercel web analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 PUBLIC_PAYLOAD_CMS_URL=
 GITHUB_TOKEN=
+
+# Umami web analytics configuration
+UMAMI_SCRIPT_URL=https://your-umami-domain.com/script.js
+UMAMI_WEBSITE_ID=your-umami-website-id

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,6 +32,16 @@ export default defineConfig({
         access: "public",
         default: "https://fityannugroho-cms.vercel.app",
       }),
+      UMAMI_SCRIPT_URL: envField.string({
+        optional: true,
+        context: "client",
+        access: "public",
+      }),
+      UMAMI_WEBSITE_ID: envField.string({
+        optional: true,
+        context: "client",
+        access: "public",
+      }),
     },
   },
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Head, { type Props as HeadProps } from "@/components/Head.astro";
 import "@/styles/globals.css";
+import { UMAMI_SCRIPT_URL, UMAMI_WEBSITE_ID } from "astro:env/client";
 import SpeedInsights from "@vercel/speed-insights/astro";
 
 export type Props = HeadProps;
@@ -46,7 +47,18 @@ const { title, description, ogImage } = Astro.props;
 </script>
 
 <html lang="en">
-  <Head {title} {description} {ogImage} />
+  <head>
+    <Head {title} {description} {ogImage} />
+
+    {UMAMI_SCRIPT_URL && UMAMI_WEBSITE_ID && (
+      <script
+        is:inline
+        defer
+        src={UMAMI_SCRIPT_URL}
+        data-website-id={UMAMI_WEBSITE_ID}
+      />
+    )}
+  </head>
   <body>
     <slot />
     <SpeedInsights />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
We currently use Vercel for web analytics. However, the free plan only provides data for the last 30 days.

## What is the new behavior?
This pull request introduces support for Umami web analytics to the project. [Umami](https://github.com/umami-software/umami) is open source software and can be self-hosted.

The changes add environment variable configuration, update the environment schema, and inject the Umami tracking script into the base layout if configured. Additionally, it simplifies the Vercel adapter configuration by removing the built-in web analytics option.

**Umami Analytics Integration:**

* Added `UMAMI_SCRIPT_URL` and `UMAMI_WEBSITE_ID` to `.env.example` for configuring Umami analytics.
* Updated the environment schema in `astro.config.mjs` to expose `UMAMI_SCRIPT_URL` and `UMAMI_WEBSITE_ID` to the client, making them available for client-side use.
* Imported the new environment variables in `src/layouts/BaseLayout.astro` and conditionally injected the Umami tracking script into the `<head>` section when both variables are set. [[1]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bR4) [[2]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bR50-R61)

**Vercel Adapter Configuration:**

* Removed the built-in Vercel web analytics option from the adapter configuration in `astro.config.mjs`, delegating analytics to Umami instead.
