### PR TITLE
fix: sync TOC heading IDs with RichText heading anchors

### DIFF
--- a/src/lib/toc.ts
+++ b/src/lib/toc.ts
@@ -66,6 +66,7 @@ export const extractHeadings = (
   opts?: { levels?: number[] },
 ): TocItem[] => {
   const levels = opts?.levels ?? [1, 2, 3, 4, 5, 6];
+  const slugger = slugifyWithCounter();
   const result: TocItem[] = [];
 
   const walk = (nodes: RichTextNode[]) => {
@@ -76,8 +77,7 @@ export const extractHeadings = (
         const level = Number(tag.replace("h", ""));
         if (levels.includes(level)) {
           const text = getTextFromLexicalNode(node);
-          const slugify = slugifyWithCounter();
-          const id = slugify(text || "");
+          const id = slugger(text || "");
           result.push({ id, text, level });
         }
       }


### PR DESCRIPTION
## PR Checklist
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type
- [x] Bug fix

## What is the current behavior?

The TOC's `extractHeadings()` in `src/lib/toc.ts` calls `slugifyWithCounter()` **inside the heading loop**, creating a fresh counter for each heading. When duplicate heading texts exist (e.g., two "Features" sections), the TOC generates the same `id` for both, while `RichText.tsx` correctly generates unique IDs (`features`, `features-1`). This ID mismatch causes:
- Scroll-sync fails: IntersectionObserver can't find the correct heading element
- Anchor clicks scroll to the wrong section

## What is the new behavior?

`slugifyWithCounter()` is instantiated once at the `extractHeadings()` function scope, matching the pattern used in `RichText.tsx`. This ensures both produce identical IDs for all headings, including duplicates.

## Other information

This is a 2-line surgical fix (verified via build check + browser test).